### PR TITLE
fix github actions badge url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cq-cli
 
-[![tests](https://github.com/CadQuery/cq-cli/workflows/tests/badge.svg)](https://github.com/CadQuery/cq-cli/actions)
+[![tests](https://github.com/CadQuery/cq-cli/actions/workflows/check-commit-actions.yml/badge.svg)](https://github.com/CadQuery/cq-cli/actions)
 
 ## Contents
 


### PR DESCRIPTION
I noticed the badge was green, but tests aren't passing for me. I got the url format from here: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge.