### PR TITLE
handle bytes and bytearray codec outputs in cq-cli.py

### DIFF
--- a/cq-cli.py
+++ b/cq-cli.py
@@ -390,8 +390,14 @@ def main():
             if outfile == None:
                 print(converted)
             else:
-                with open(outfile, 'w') as file:
-                    file.write(converted)
+                if isinstance(converted, str):
+                    with open(outfile, 'w') as file:
+                        file.write(converted)
+                elif isinstance(converted, (bytes, bytearray)):
+                    with open(outfile, 'wb') as file:
+                        file.write(converted)
+                else:
+                    raise TypeError("Expected converted output to be str, bytes, or bytearray. Got '%s'" % type(converted).__name__)
 
     except Exception:
         out_tb = traceback.format_exc()


### PR DESCRIPTION
I see that gltf was added very recently, so this is probably already on your radar. If you have another fix for this in progress, feel free to close this PR.

I see that in cadquery, gltf export of assemblies hardcodes `binary=True` here: https://github.com/CadQuery/cadquery/blob/f467ac95051a112eee3f3767532d9eb58d80e9d7/cadquery/assembly.py#L491, so the `binary=False` in `cq_codec_gltf.py` is ignored.

With binary output, a couple changes were needed in `cq-cli.py` to optionally open the output file in binary-writing mode.

I'm happy to update the tests if you're ok with this fix. Not sure if you were planning to modify cadquery to make binary gltf output optional.