### PR TITLE
Add an --expression flag to specify what cq-cli should render

### DIFF
--- a/src/cq_cli/main.py
+++ b/src/cq_cli/main.py
@@ -20,17 +20,15 @@ import json
 from cq_cli.cqcodecs import loader
 
 
-def build_and_parse(script_str, params, errfile, entrypoint):
+def build_and_parse(script_str, params, errfile, expression):
     """
     Uses CQGI to parse and build a script, substituting in parameters if any were supplied.
     """
     # We need to do a broad try/catch to let the user know if something higher-level fails
     try:
         # Do the CQGI handling of the script here and, if successful, pass the build result to the codec
-        if entrypoint != None:
-            if not entrypoint.isidentifier():
-                raise ValueError("Entrypoint is not a valid python function name")
-            script_str += "\nshow_object({f}())".format(f=entrypoint)
+        if expression != None:
+            script_str += "\nshow_object({expr})".format(expr=expression)
         cqModel = cqgi.parse(script_str)
         build_result = cqModel.build(params)
 
@@ -186,8 +184,8 @@ def main():
         help="Setting to true forces the CLI to only parse and validate the script and not produce converted output.",
     )
     parser.add_argument(
-        "--entrypoint",
-        help="The name of a python function that returns a cadquery model object. cq-cli will call the function and render the resulting object. This allows rendering different models/parts from the same python file.",
+        "--expression",
+        help="A python expression (such as `my_shape(x=5)`) to evaluate and render. This allows rendering different models/parts from the same python file.",
     )
 
     args = parser.parse_args()
@@ -231,7 +229,7 @@ def main():
         # Set the PYTHONPATH variable to the current directory to allow module loading
         set_pythonpath_for_infile(args.infile)
 
-        build_result = build_and_parse(script_str, params, errfile, args.entrypoint)
+        build_result = build_and_parse(script_str, params, errfile, args.expression)
 
         # Double-check that the build was a success
         if build_result != None and build_result.success:
@@ -432,7 +430,7 @@ def main():
     #
     build_result = None
     try:
-        build_result = build_and_parse(script_str, params, errfile, args.entrypoint)
+        build_result = build_and_parse(script_str, params, errfile, args.expression)
 
         # If None was returned, it means the build failed and the exception has already been reported
         if build_result == None:

--- a/src/cq_cli/main.py
+++ b/src/cq_cli/main.py
@@ -28,7 +28,9 @@ def build_and_parse(script_str, params, errfile, entrypoint):
     try:
         # Do the CQGI handling of the script here and, if successful, pass the build result to the codec
         if entrypoint != None:
-            script_str += "\n" + entrypoint
+            if not entrypoint.isidentifier():
+                raise ValueError("Entrypoint is not a valid python function name")
+            script_str += "\nshow_object({f}())".format(f=entrypoint)
         cqModel = cqgi.parse(script_str)
         build_result = cqModel.build(params)
 
@@ -185,7 +187,7 @@ def main():
     )
     parser.add_argument(
         "--entrypoint",
-        help="A snippet of python code to append to the input file before rendering. This allows rendering different models/parts from the same python file.",
+        help="The name of a python function that returns a cadquery model object. cq-cli will call the function and render the resulting object. This allows rendering different models/parts from the same python file.",
     )
 
     args = parser.parse_args()

--- a/src/cq_cli/main.py
+++ b/src/cq_cli/main.py
@@ -185,7 +185,7 @@ def main():
     )
     parser.add_argument(
         "--entrypoint",
-        help="A snipped of python code to append to the input file before rendering. This allows rendering different models/parts from the same python file.",
+        help="A snippet of python code to append to the input file before rendering. This allows rendering different models/parts from the same python file.",
     )
 
     args = parser.parse_args()

--- a/src/cq_cli/main.py
+++ b/src/cq_cli/main.py
@@ -20,13 +20,15 @@ import json
 from cq_cli.cqcodecs import loader
 
 
-def build_and_parse(script_str, params, errfile):
+def build_and_parse(script_str, params, errfile, entrypoint):
     """
     Uses CQGI to parse and build a script, substituting in parameters if any were supplied.
     """
     # We need to do a broad try/catch to let the user know if something higher-level fails
     try:
         # Do the CQGI handling of the script here and, if successful, pass the build result to the codec
+        if entrypoint != None:
+            script_str += "\n" + entrypoint
         cqModel = cqgi.parse(script_str)
         build_result = cqModel.build(params)
 
@@ -181,6 +183,10 @@ def main():
         "--validate",
         help="Setting to true forces the CLI to only parse and validate the script and not produce converted output.",
     )
+    parser.add_argument(
+        "--entrypoint",
+        help="A snipped of python code to append to the input file before rendering. This allows rendering different models/parts from the same python file.",
+    )
 
     args = parser.parse_args()
 
@@ -223,7 +229,7 @@ def main():
         # Set the PYTHONPATH variable to the current directory to allow module loading
         set_pythonpath_for_infile(args.infile)
 
-        build_result = build_and_parse(script_str, params, errfile)
+        build_result = build_and_parse(script_str, params, errfile, args.entrypoint)
 
         # Double-check that the build was a success
         if build_result != None and build_result.success:
@@ -424,7 +430,7 @@ def main():
     #
     build_result = None
     try:
-        build_result = build_and_parse(script_str, params, errfile)
+        build_result = build_and_parse(script_str, params, errfile, args.entrypoint)
 
         # If None was returned, it means the build failed and the exception has already been reported
         if build_result == None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -407,3 +407,53 @@ def test_exit_codes():
 
     # Make sure that we got exit code 100 for a failed model build
     assert exitcode == 100
+
+
+def test_expression_argument():
+    """
+    Tests the CLI with the the expression argument.
+    """
+    test_file = helpers.get_test_file_location("no_toplevel_objects.py")
+
+    # Get a temporary output file location
+    temp_dir = tempfile.gettempdir()
+    temp_file = os.path.join(temp_dir, "temp_test_10.step")
+
+    command = [
+        "python",
+        "src/cq_cli/main.py",
+        "--codec",
+        "step",
+        "--infile",
+        test_file,
+        "--outfile",
+        temp_file,
+        "--expression",
+        "cube()",
+    ]
+    out, err, exitcode = helpers.cli_call(command)
+
+    # Read the STEP output back from the outfile
+    with open(temp_file, "r") as file:
+        step_str = file.read()
+
+    assert step_str.startswith("ISO-10303-21;")
+
+    # Run cq-cli on the same model file, but don't specify an --expression. This
+    # should fail because the file contains no top-level show_object() calls.
+    command = [
+        "python",
+        "src/cq_cli/main.py",
+        "--codec",
+        "step",
+        "--infile",
+        test_file,
+        "--outfile",
+        temp_file,
+    ]
+    out, err, exitcode = helpers.cli_call(command)
+
+    print("err: %s" % err.decode())
+
+    # cq-cli invocation should fail
+    assert exitcode == 200

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -419,6 +419,7 @@ def test_expression_argument():
     temp_dir = tempfile.gettempdir()
     temp_file = os.path.join(temp_dir, "temp_test_10.step")
 
+    # Run cq-cli with --expression "cube()"
     command = [
         "python",
         "src/cq_cli/main.py",
@@ -452,8 +453,6 @@ def test_expression_argument():
         temp_file,
     ]
     out, err, exitcode = helpers.cli_call(command)
-
-    print("err: %s" % err.decode())
 
     # cq-cli invocation should fail
     assert exitcode == 200

--- a/tests/testdata/no_toplevel_objects.py
+++ b/tests/testdata/no_toplevel_objects.py
@@ -1,0 +1,7 @@
+import cadquery as cq
+
+# This test file contains a method for creating a shape, but does not contain
+# any top-level `show_object()` calls.
+
+def cube():
+    return cq.Workplane().box(1, 1, 1)

--- a/tests/testdata/no_toplevel_objects.py
+++ b/tests/testdata/no_toplevel_objects.py
@@ -3,5 +3,6 @@ import cadquery as cq
 # This test file contains a method for creating a shape, but does not contain
 # any top-level `show_object()` calls.
 
+
 def cube():
     return cq.Workplane().box(1, 1, 1)


### PR DESCRIPTION
This is an attempt to implement the feature in https://github.com/CadQuery/cq-cli/issues/18.

Usage: `cq-cli --infile model.py --outfile out.step --entrypoint="show_object(mypart())"`

As-is, this requires `show_object` to be part of the entrypoint, which doesn't seem great, but I don't think it's too unexpected for users since the code in `--infile` previously would require at least one call to `show_object` anyways. Making `--entrypoint` not require the `show_object` call may be quite a pain, as you outlined in https://github.com/CadQuery/cq-cli/issues/18#issuecomment-1771203435

Other potential names for the flag: --expr/--expression, --snippet?