### PR TITLE
Add binary gltf support (.glb)

### DIFF
--- a/src/cq_cli/cqcodecs/cq_codec_glb.py
+++ b/src/cq_cli/cqcodecs/cq_codec_glb.py
@@ -1,0 +1,25 @@
+import os, tempfile
+import cq_cli.cqcodecs.codec_helpers as helpers
+
+
+def convert(build_result, output_file=None, error_file=None, output_opts=None):
+    # Create a temporary file to put the STL output into
+    temp_dir = tempfile.gettempdir()
+    temp_file = os.path.join(temp_dir, "temp_glb.glb")
+
+    # The exporters will add extra output that we do not want, so suppress it
+    with helpers.suppress_stdout_stderr():
+        # Put the GLB output into the temp file
+        # Check to see if we are dealing with an assembly or a single object
+        if type(build_result.first_result.shape).__name__ == "Assembly":
+            build_result.first_result.shape.save(temp_file, binary=True)
+        else:
+            raise ValueError(
+                "GLB export is only available for CadQuery assemblies at this time"
+            )
+
+    # Read the GLB output back in
+    with open(temp_file, "rb") as file:
+        glb_data = file.read()
+
+    return glb_data

--- a/tests/test_glb_codec.py
+++ b/tests/test_glb_codec.py
@@ -19,5 +19,3 @@ def test_glb_codec():
     out, err, exitcode = helpers.cli_call(command)
 
     assert out.decode().startswith("b'glTF")
-
-

--- a/tests/test_glb_codec.py
+++ b/tests/test_glb_codec.py
@@ -1,0 +1,23 @@
+import pytest
+import tests.test_helpers as helpers
+
+
+def test_glb_codec():
+    """
+    Basic test of the GLB codec plugin.
+    """
+    test_file = helpers.get_test_file_location("cube_assy.py")
+
+    command = [
+        "python",
+        "src/cq_cli/main.py",
+        "--codec",
+        "glb",
+        "--infile",
+        test_file,
+    ]
+    out, err, exitcode = helpers.cli_call(command)
+
+    assert out.decode().startswith("b'glTF")
+
+


### PR DESCRIPTION
Adding glb support as no codec existed. It is in a new module rather than in the existing gltf one as I couldn't see how to make it work in the existing one.