### PR TITLE
Added multiple file export at once

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "cadquery-ocp>=7.7.0a0,<7.8",
   "ezdxf",
   "multimethod>=1.7,<2.0",
+  "numpy<2.0.0",
   "nlopt",
   "typish",
   "casadi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
   "ezdxf",
   "multimethod>=1.7,<2.0",
   "nlopt",
-  "nptyping==2.0.1",
   "typish",
   "casadi",
   "path",

--- a/src/cq_cli/main.py
+++ b/src/cq_cli/main.py
@@ -502,7 +502,9 @@ def main():
                 codec_module = active_codecs[i]
 
             # Use the codec plugin to do the conversion
-            converted = codec_module.convert(build_result, outfile, errfile, output_opts)
+            converted = codec_module.convert(
+                build_result, outfile, errfile, output_opts
+            )
 
             # If converted is None, assume that the output was written to file directly by the codec
             if converted != None:

--- a/src/cq_cli/main.py
+++ b/src/cq_cli/main.py
@@ -158,7 +158,7 @@ def main():
     )
     parser.add_argument(
         "--codec",
-        help="The codec to use when converting the CadQuery output. Must match the name of a codec file in the cqcodecs directory.  Multiple codecs can be specified, separated by the colon (;) character. The number of codecs must match the number of output files (outfile parameter).",
+        help="(REQUIRED) The codec to use when converting the CadQuery output. Must match the name of a codec file in the cqcodecs directory.  Multiple codecs can be specified, separated by the colon (;) character. The number of codecs must match the number of output files (outfile parameter).",
     )
     parser.add_argument(
         "--getparams",

--- a/src/cq_cli/main.py
+++ b/src/cq_cli/main.py
@@ -330,26 +330,9 @@ def main():
     codec = args.codec
 
     # Handle multiple output files
-    if ";" in codec:
+    if codec != None and ";" in codec:
         codecs = codec.split(";")
         codec = codecs[0]
-
-    # Do the first check to make sure the codecs match the number of output files
-    if (outfiles != None and codecs == None) or (outfiles == None and codecs != None):
-        print(
-            "The number of codecs does not match the number of output files.",
-            file=sys.stderr,
-        )
-        sys.exit(4)
-
-    # Make sure the codecs match the number of output files
-    if outfiles != None and codecs != None:
-        if len(outfiles) != len(codecs):
-            print(
-                "The number of codecs does not match the number of output files.",
-                file=sys.stderr,
-            )
-            sys.exit(4)
 
     # Attempt to auto-detect the codec if the user has not set the option
     if args.outfile != None and args.codec == None:
@@ -359,6 +342,24 @@ def main():
             codec_temp = "cq_codec_" + codec_temp
             if codec_temp in loaded_codecs:
                 codec = codec_temp
+
+    # If there are multiple output files, make sure to set the codecs for all of them
+    if outfiles != None and codecs == None:
+        codecs = []
+        for i in range(len(outfiles)):
+            codec_temp = outfiles[i].split(".")[-1]
+            if codec_temp != None:
+                # Construct the codec module name
+                codec_temp = "cq_codec_" + codec_temp
+
+                if codec_temp in loaded_codecs:
+                    # The codecs array needs just the short name, not the full module name
+                    codecs.append(codec_temp.replace("cq_codec_", ""))
+
+                    # Keep track of the codes that are being actively used
+                    if active_codecs == None:
+                        active_codecs = []
+                    active_codecs.append(loaded_codecs[codec_temp])
 
     # If the user has not supplied a codec, they need to be validating the script
     if (codec == None and args.outfile == None) and (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -456,3 +456,54 @@ def test_expression_argument():
 
     # cq-cli invocation should fail
     assert exitcode == 200
+
+
+def test_multiple_outfiles():
+    """
+    Tests the CLI with multiple output files specified.
+    """
+    test_file = helpers.get_test_file_location("cube.py")
+
+    # Get a temporary output file location
+    temp_dir = tempfile.gettempdir()
+    temp_file_step = os.path.join(temp_dir, "temp_test_11.step")
+    temp_file_stl = os.path.join(temp_dir, "temp_test_11.stl")
+    temp_paths = temp_file_step + ";" + temp_file_stl
+
+    command = [
+        "python",
+        "src/cq_cli/main.py",
+        "--codec",
+        "step;stl",
+        "--infile",
+        test_file,
+         "--outfile",
+        temp_paths,
+    ]
+    out, err, exitcode = helpers.cli_call(command)
+    assert exitcode == 0
+
+def test_multiple_outfiles_codec_mismatch():
+    """
+    Tests the CLI with multiple output files specified and a different number of codecs specified.
+    """
+    test_file = helpers.get_test_file_location("cube.py")
+
+    # Get a temporary output file location
+    temp_dir = tempfile.gettempdir()
+    temp_file_step = os.path.join(temp_dir, "temp_test_11.step")
+    temp_file_stl = os.path.join(temp_dir, "temp_test_11.stl")
+    temp_paths = temp_file_step + ";" + temp_file_stl
+
+    command = [
+        "python",
+        "src/cq_cli/main.py",
+        "--codec",
+        "step",
+        "--infile",
+        test_file,
+         "--outfile",
+        temp_paths,
+    ]
+    out, err, exitcode = helpers.cli_call(command)
+    assert exitcode == 4

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -477,11 +477,12 @@ def test_multiple_outfiles():
         "step;stl",
         "--infile",
         test_file,
-         "--outfile",
+        "--outfile",
         temp_paths,
     ]
     out, err, exitcode = helpers.cli_call(command)
     assert exitcode == 0
+
 
 def test_multiple_outfiles_codec_mismatch():
     """
@@ -502,7 +503,7 @@ def test_multiple_outfiles_codec_mismatch():
         "step",
         "--infile",
         test_file,
-         "--outfile",
+        "--outfile",
         temp_paths,
     ]
     out, err, exitcode = helpers.cli_call(command)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,6 +117,68 @@ def test_codec_infile_outfile_errfile_arguments():
     assert err_str == "Argument error: infile does not exist."
 
 
+def test_no_codec_parameter():
+    """
+    Tests the CLI's ability to infer the codec from the outfile extension.
+    """
+    test_file = helpers.get_test_file_location("cube.py")
+
+    # Get a temporary output file location
+    temp_dir = tempfile.gettempdir()
+    temp_file = os.path.join(temp_dir, "temp_test_12.step")
+
+    command = [
+        "python",
+        "src/cq_cli/main.py",
+        "--infile",
+        test_file,
+        "--outfile",
+        temp_file,
+    ]
+    out, err, exitcode = helpers.cli_call(command)
+
+    # Read the STEP output back from the outfile
+    with open(temp_file, "r") as file:
+        step_str = file.read()
+
+    assert step_str.startswith("ISO-10303-21;")
+
+
+def test_no_codec_parameter_multiple_infiles():
+    """
+    Tests the CLI's ability to infer the codecs from multiple infile extensions.
+    """
+    test_file = helpers.get_test_file_location("cube.py")
+
+    # Get a temporary output file location
+    temp_dir = tempfile.gettempdir()
+    temp_file_step = os.path.join(temp_dir, "temp_test_13.step")
+    temp_file_stl = os.path.join(temp_dir, "temp_test_13.stl")
+    temp_paths = temp_file_step + ";" + temp_file_stl
+
+    command = [
+        "python",
+        "src/cq_cli/main.py",
+        "--infile",
+        test_file,
+        "--outfile",
+        temp_paths,
+    ]
+    out, err, exitcode = helpers.cli_call(command)
+
+    # Read the STEP output back from the outfile to make sure it has the correct content
+    with open(temp_file_step, "r") as file:
+        step_str = file.read()
+    assert step_str.startswith("ISO-10303-21;")
+
+    # Read the STL output back from the outfile to make sure it has the correct content
+    with open(temp_file_stl, "r") as file:
+        stl_str = file.read()
+    assert stl_str.startswith("solid")
+
+    assert exitcode == 0
+
+
 def test_parameter_file():
     """
     Tests the CLI's ability to load JSON parameters from a file.
@@ -482,29 +544,3 @@ def test_multiple_outfiles():
     ]
     out, err, exitcode = helpers.cli_call(command)
     assert exitcode == 0
-
-
-def test_multiple_outfiles_codec_mismatch():
-    """
-    Tests the CLI with multiple output files specified and a different number of codecs specified.
-    """
-    test_file = helpers.get_test_file_location("cube.py")
-
-    # Get a temporary output file location
-    temp_dir = tempfile.gettempdir()
-    temp_file_step = os.path.join(temp_dir, "temp_test_11.step")
-    temp_file_stl = os.path.join(temp_dir, "temp_test_11.stl")
-    temp_paths = temp_file_step + ";" + temp_file_stl
-
-    command = [
-        "python",
-        "src/cq_cli/main.py",
-        "--codec",
-        "step",
-        "--infile",
-        test_file,
-        "--outfile",
-        temp_paths,
-    ]
-    out, err, exitcode = helpers.cli_call(command)
-    assert exitcode == 4


### PR DESCRIPTION
This PR adds the ability to specify multiple output files at once in the `outfile` parameter by separating them with a `;` character. The number of codecs specified via the `codec` parameter should match the number of output files. This prevents users from having to invoke cq-cli from scratch for each different export format they want of a single model.

@justbuchanan If you have the time and interest, please review. If you do not, I'll merge in a few days.