### PR TITLE
Add binary option to stl codec

### DIFF
--- a/src/cq_cli/cqcodecs/cq_codec_stl.py
+++ b/src/cq_cli/cqcodecs/cq_codec_stl.py
@@ -18,6 +18,10 @@ def convert(build_result, output_file=None, error_file=None, output_opts=None):
     if output_opts and "angularDeflection" in output_opts:
         angularDeflection = output_opts["angularDeflection"]
 
+    use_ascii = True
+    if output_opts and "binary" in output_opts:
+        use_ascii = not output_opts["binary"]
+
     # The exporters will add extra output that we do not want, so suppress it
     with helpers.suppress_stdout_stderr():
         # There should be a shape in the build results
@@ -30,7 +34,7 @@ def convert(build_result, output_file=None, error_file=None, output_opts=None):
             result = result.val()
 
         # Put the STL output into the temp file
-        result.exportStl(temp_file, linearDeflection, angularDeflection, True)
+        result.exportStl(temp_file, linearDeflection, angularDeflection, use_ascii)
 
     # Read the STL output back in
     with open(temp_file, "rb") as file:

--- a/tests/test_stl_codec.py
+++ b/tests/test_stl_codec.py
@@ -164,3 +164,24 @@ def test_stl_codec_assembly_to_file(tmp_path):
     assert exitcode == 0
     content = out_path.read_bytes()
     assert content[:5] == b"solid"
+
+
+def test_stl_codec_binary():
+    """
+    Tests exporting to binary stl format.
+    """
+    test_file = helpers.get_test_file_location("cube.py")
+
+    command = [
+        sys.executable,
+        "src/cq_cli/main.py",
+        "--codec",
+        "stl",
+        "--infile",
+        test_file,
+        "--outputopts",
+        "binary:True",
+    ]
+    out, err, exitcode = helpers.cli_call(command)
+
+    assert out[:5] != b"solid"


### PR DESCRIPTION
Relevant issue: #29 

I have added a `binary` option to the `stl` codec. This should be `True` or `False`

Default encoding is still ASCII for reasons discussed in the issue.

I have added a relevant test.